### PR TITLE
Convert WorkDo auto puncher to tray application with settings UI

### DIFF
--- a/ConsoleApp1/MainForm.cs
+++ b/ConsoleApp1/MainForm.cs
@@ -1,0 +1,318 @@
+using System;
+using System.Configuration;
+using System.Drawing;
+using System.IO;
+using System.Windows.Forms;
+using Utility.Helper;
+using WorkDoService;
+
+namespace WorkDoWinService
+{
+    internal class MainForm : Form
+    {
+        private readonly NotifyIcon _trayIcon;
+        private readonly ContextMenuStrip _trayMenu;
+        private readonly ToolStripMenuItem _openMenuItem;
+        private readonly ToolStripMenuItem _exitMenuItem;
+        private readonly Label _statusLabel;
+        private TextBox _gpsLocationTextBox;
+        private TextBox _gpsPlaceTextBox;
+        private TextBox _clockInTextBox;
+        private TextBox _clockOutTextBox;
+        private Button _saveButton;
+        private bool _allowClose;
+        private MainService _service;
+
+        public MainForm()
+        {
+            AutoScaleMode = AutoScaleMode.Font;
+            StartPosition = FormStartPosition.CenterScreen;
+            Text = "WorkDo 自動打卡";
+            MinimumSize = new Size(500, 320);
+
+            Icon appIcon = LoadApplicationIcon();
+            Icon = appIcon;
+
+            _trayMenu = new ContextMenuStrip();
+            _openMenuItem = new ToolStripMenuItem("開啟", null, (_, __) => ShowMainWindow());
+            _exitMenuItem = new ToolStripMenuItem("結束", null, (_, __) => ExitApplication());
+            _trayMenu.Items.Add(_openMenuItem);
+            _trayMenu.Items.Add(new ToolStripSeparator());
+            _trayMenu.Items.Add(_exitMenuItem);
+
+            _trayIcon = new NotifyIcon
+            {
+                Icon = appIcon,
+                Visible = true,
+                Text = "WorkDo 自動打卡"
+            };
+            _trayIcon.DoubleClick += (_, __) => ShowMainWindow();
+            _trayIcon.ContextMenuStrip = _trayMenu;
+
+            BuildLayout();
+            LoadSettings();
+            StartService();
+
+            Resize += OnResize;
+            FormClosing += OnFormClosing;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                StopService();
+                if (_trayIcon != null)
+                {
+                    _trayIcon.Visible = false;
+                    _trayIcon.Dispose();
+                }
+                _trayMenu?.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        private void BuildLayout()
+        {
+            var layout = new TableLayoutPanel
+            {
+                Dock = DockStyle.Fill,
+                ColumnCount = 2,
+                RowCount = 6,
+                Padding = new Padding(16),
+                AutoSize = true,
+                AutoSizeMode = AutoSizeMode.GrowAndShrink
+            };
+
+            layout.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
+            layout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100f));
+
+            _gpsLocationTextBox = CreateTextBox();
+            _gpsPlaceTextBox = CreateTextBox();
+            _clockInTextBox = CreateTextBox();
+            _clockOutTextBox = CreateTextBox();
+
+            layout.Controls.Add(CreateLabel("GPS 座標"), 0, 0);
+            layout.Controls.Add(_gpsLocationTextBox, 1, 0);
+
+            layout.Controls.Add(CreateLabel("地址"), 0, 1);
+            layout.Controls.Add(_gpsPlaceTextBox, 1, 1);
+
+            layout.Controls.Add(CreateLabel("上班時間"), 0, 2);
+            layout.Controls.Add(_clockInTextBox, 1, 2);
+
+            layout.Controls.Add(CreateLabel("下班時間"), 0, 3);
+            layout.Controls.Add(_clockOutTextBox, 1, 3);
+
+            _saveButton = new Button
+            {
+                Text = "儲存設定",
+                AutoSize = true,
+                Anchor = AnchorStyles.Right,
+                Padding = new Padding(10, 4, 10, 4)
+            };
+            _saveButton.Click += (_, __) => SaveSettings();
+
+            layout.Controls.Add(_saveButton, 1, 4);
+
+            _statusLabel = new Label
+            {
+                AutoSize = true,
+                ForeColor = Color.DimGray,
+                Margin = new Padding(3, 12, 3, 0)
+            };
+            layout.Controls.Add(_statusLabel, 0, 5);
+            layout.SetColumnSpan(_statusLabel, 2);
+
+            Controls.Add(layout);
+        }
+
+        private static Label CreateLabel(string text)
+        {
+            return new Label
+            {
+                Text = text,
+                AutoSize = true,
+                Anchor = AnchorStyles.Left,
+                Margin = new Padding(3, 6, 3, 6)
+            };
+        }
+
+        private static TextBox CreateTextBox()
+        {
+            return new TextBox
+            {
+                Anchor = AnchorStyles.Left | AnchorStyles.Right,
+                Width = 320
+            };
+        }
+
+        private Icon LoadApplicationIcon()
+        {
+            var baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
+            var iconPath = Path.Combine(baseDirectory, "WorkdoAuto.ico");
+            if (File.Exists(iconPath))
+            {
+                return new Icon(iconPath);
+            }
+
+            using (var stream = typeof(MainForm).Assembly.GetManifestResourceStream("WorkDoWinService.WorkdoAuto.ico"))
+            {
+                if (stream != null)
+                {
+                    return new Icon(stream);
+                }
+            }
+
+            return SystemIcons.Application;
+        }
+
+        private void LoadSettings()
+        {
+            try
+            {
+                var helper = ConfigHelper.GetInstance();
+                _gpsLocationTextBox.Text = helper.GetAppSettingValue("gpsLocation");
+                _gpsPlaceTextBox.Text = helper.GetAppSettingValue("gpsPlace");
+                _clockInTextBox.Text = helper.GetAppSettingValue("ClockIn");
+                _clockOutTextBox.Text = helper.GetAppSettingValue("ClockOut");
+                UpdateStatus("設定已載入。");
+            }
+            catch (ConfigurationErrorsException ex)
+            {
+                UpdateStatus("讀取設定失敗：" + ex.Message, true);
+            }
+            catch (Exception ex)
+            {
+                UpdateStatus("讀取設定發生錯誤：" + ex.Message, true);
+            }
+        }
+
+        private void SaveSettings()
+        {
+            try
+            {
+                var helper = ConfigHelper.GetInstance();
+                helper.SetAppSettingValue("gpsLocation", _gpsLocationTextBox.Text.Trim());
+                helper.SetAppSettingValue("gpsPlace", _gpsPlaceTextBox.Text.Trim());
+                helper.SetAppSettingValue("ClockIn", _clockInTextBox.Text.Trim());
+                helper.SetAppSettingValue("ClockOut", _clockOutTextBox.Text.Trim());
+
+                RestartService();
+                UpdateStatus("設定已儲存並重新啟動排程服務。");
+                _trayIcon.ShowBalloonTip(2000, Text, "設定已儲存。", ToolTipIcon.Info);
+            }
+            catch (ConfigurationErrorsException ex)
+            {
+                UpdateStatus("儲存設定失敗：" + ex.Message, true);
+                MessageBox.Show(ex.Message, Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+            catch (Exception ex)
+            {
+                UpdateStatus("儲存設定發生錯誤：" + ex.Message, true);
+                MessageBox.Show(ex.Message, Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+
+        private void StartService()
+        {
+            try
+            {
+                _service = new MainService();
+                _service.Start();
+                UpdateStatus("排程服務執行中。");
+            }
+            catch (Exception ex)
+            {
+                _service = null;
+                UpdateStatus("排程服務啟動失敗：" + ex.Message, true);
+                MessageBox.Show(ex.Message, Text, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            }
+        }
+
+        private void RestartService()
+        {
+            StopService();
+            StartService();
+        }
+
+        private void StopService()
+        {
+            if (_service != null)
+            {
+                try
+                {
+                    _service.Stop();
+                }
+                catch
+                {
+                    // ignore exceptions during shutdown
+                }
+                finally
+                {
+                    _service = null;
+                }
+            }
+        }
+
+        private void ShowMainWindow()
+        {
+            if (Visible)
+            {
+                if (WindowState == FormWindowState.Minimized)
+                {
+                    WindowState = FormWindowState.Normal;
+                }
+            }
+            else
+            {
+                Show();
+                WindowState = FormWindowState.Normal;
+            }
+
+            Activate();
+        }
+
+        private void ExitApplication()
+        {
+            _allowClose = true;
+            _trayIcon.Visible = false;
+            Close();
+        }
+
+        private void OnResize(object sender, EventArgs e)
+        {
+            if (WindowState == FormWindowState.Minimized)
+            {
+                Hide();
+                _trayIcon.ShowBalloonTip(1500, Text, "程式仍在系統列執行。", ToolTipIcon.Info);
+            }
+        }
+
+        private void OnFormClosing(object sender, FormClosingEventArgs e)
+        {
+            if (!_allowClose && e.CloseReason == CloseReason.UserClosing)
+            {
+                e.Cancel = true;
+                Hide();
+            }
+            else if (_allowClose)
+            {
+                StopService();
+            }
+        }
+
+        private void UpdateStatus(string message, bool isError = false)
+        {
+            if (_statusLabel.InvokeRequired)
+            {
+                _statusLabel.Invoke(new Action(() => UpdateStatus(message, isError)));
+                return;
+            }
+
+            _statusLabel.Text = message;
+            _statusLabel.ForeColor = isError ? Color.Firebrick : Color.DimGray;
+        }
+    }
+}

--- a/ConsoleApp1/Program.cs
+++ b/ConsoleApp1/Program.cs
@@ -1,35 +1,26 @@
-﻿using System;
+using System;
 using System.Text;
-using Topshelf;
-using WorkDoService;
+using System.Windows.Forms;
 
 namespace WorkDoWinService
 {
-    internal class Program
+    internal static class Program
     {
-        static void Main(string[] args)
+        [STAThread]
+        private static void Main()
         {
+            Application.EnableVisualStyles();
+            Application.SetCompatibleTextRenderingDefault(false);
             Console.OutputEncoding = Encoding.UTF8;
-            HostFactory.Run(x =>
-            {
-                x.Service<MainService>(s =>
-                {
-                    s.ConstructUsing(name => new MainService());
-                    s.WhenStarted(ms => ms.Start());
-                    s.WhenStopped(ms => ms.Stop());
-                });
 
-                x.SetServiceName("WorkDoAutoPunchService");
-                x.SetDisplayName("WorkDoAutoPunchService");
-                x.SetDescription("WorkDoAutoPunchService");
-                x.RunAsLocalSystem();
-                x.StartAutomatically();
-            });
-            //底下為測試用Code
-            //DateTime Time_PunchIn = DateTime.Now.Date + TimeSpan.Parse(ConfigHelper.GetInstance().GetAppSettingValue("ClockIn"));
-            //var service = new Simulation();
-            //service.LoginSimulation();
-            //service.PunchOut();
+            try
+            {
+                Application.Run(new MainForm());
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.Message, "WorkDoAutoPunchService", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
         }
     }
 }

--- a/ConsoleApp1/WorkDoWinService.csproj
+++ b/ConsoleApp1/WorkDoWinService.csproj
@@ -5,7 +5,7 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{A41EC701-4440-4513-B391-F190E5AEC6DF}</ProjectGuid>
-    <OutputType>Exe</OutputType>
+    <OutputType>WinExe</OutputType>
     <RootNamespace>WorkDoWinService</RootNamespace>
     <AssemblyName>WorkDoWinService</AssemblyName>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
@@ -53,6 +53,9 @@
   </PropertyGroup>
   <PropertyGroup>
     <SignManifests>false</SignManifests>
+  </PropertyGroup>
+  <PropertyGroup>
+    <ApplicationIcon>WorkdoAuto.ico</ApplicationIcon>
   </PropertyGroup>
   <PropertyGroup>
     <ManifestCertificateThumbprint>5A12528EE5E6F10E10CB5014D73D8D90A1717885</ManifestCertificateThumbprint>
@@ -108,6 +111,8 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Runtime.Remoting" />
+    <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.ServiceProcess" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -115,19 +120,18 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="Topshelf, Version=4.3.0.0, Culture=neutral, PublicKeyToken=b800c4cfcdeea87b, processorArchitecture=MSIL">
-      <HintPath>..\packages\Topshelf.4.3.0\lib\net452\Topshelf.dll</HintPath>
-    </Reference>
-    <Reference Include="Topshelf.Quartz, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Topshelf.Quartz.0.4.0.1\lib\net45\Topshelf.Quartz.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="MainForm.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
+    <None Include="..\WorkdoAuto.ico">
+      <Link>WorkdoAuto.ico</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="InstallService.bat">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/ConsoleApp1/packages.config
+++ b/ConsoleApp1/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Common.Logging" version="3.4.1" targetFramework="net472" />
   <package id="Common.Logging.Core" version="3.4.1" targetFramework="net472" />
@@ -13,6 +13,4 @@
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net472" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net472" />
-  <package id="Topshelf" version="4.3.0" targetFramework="net472" />
-  <package id="Topshelf.Quartz" version="0.4.0.1" targetFramework="net472" />
 </packages>

--- a/Utility/Helper/ConfigHelper.cs
+++ b/Utility/Helper/ConfigHelper.cs
@@ -75,6 +75,59 @@ namespace Utility.Helper
         }
 
         /// <summary>
+        /// 更新組態檔應用程式設定項目值
+        /// </summary>
+        /// <param name="key">應用程式設定項目鍵值</param>
+        /// <param name="value">應用程式設定項目值</param>
+        public void SetAppSettingValue(string key, string value)
+        {
+            if (String.IsNullOrWhiteSpace(key))
+            {
+                throw new ArgumentException("Key cannot be null or whitespace.", nameof(key));
+            }
+
+            bool hasUpdated = false;
+            List<Configuration> configList = OpenApConfiguration();
+
+            if (configList != null && configList.Count > 0)
+            {
+                foreach (var config in configList)
+                {
+                    if (config == null || config.AppSettings?.Settings == null)
+                    {
+                        continue;
+                    }
+
+                    var settings = config.AppSettings.Settings;
+                    if (settings[key] != null)
+                    {
+                        settings[key].Value = value;
+                        config.Save(ConfigurationSaveMode.Modified);
+                        ConfigurationManager.RefreshSection("appSettings");
+                        hasUpdated = true;
+                        break;
+                    }
+                }
+            }
+
+            if (!hasUpdated)
+            {
+                Configuration config = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
+                if (config.AppSettings.Settings[key] != null)
+                {
+                    config.AppSettings.Settings[key].Value = value;
+                }
+                else
+                {
+                    config.AppSettings.Settings.Add(key, value);
+                }
+
+                config.Save(ConfigurationSaveMode.Modified);
+                ConfigurationManager.RefreshSection("appSettings");
+            }
+        }
+
+        /// <summary>
         /// 讀取組態檔資料庫連線字串設定項目值
         /// </summary>
         /// <param name="key">資料庫連線字串設定項目鍵值</param>

--- a/WorkDoService/MainService.cs
+++ b/WorkDoService/MainService.cs
@@ -41,7 +41,7 @@ namespace WorkDoService
             else
             {
                 Console.WriteLine($"CronExpression is NOT valid !! Please check your config file.");
-                Console.ReadKey();
+                throw new InvalidOperationException("CronExpression is NOT valid. Please check your config file.");
             }
 
             IJobDetail _clockIn_Job = JobBuilder.Create<ClockInJob>()
@@ -101,7 +101,11 @@ namespace WorkDoService
         public void Stop()
         {
 
-            _clockIn_scheduler_Daily.Shutdown();
+            if (_clockIn_scheduler_Daily != null)
+            {
+                _clockIn_scheduler_Daily.Shutdown();
+            }
+
             Console.WriteLine("Service Stop.");
         }
 


### PR DESCRIPTION
## Summary
- replace the Topshelf console host with a WinForms tray application that uses WorkdoAuto.ico
- add a resident user interface for editing gpsLocation, gpsPlace, ClockIn, and ClockOut settings and restarting the scheduler
- extend the configuration helper to persist updates and improve service shutdown handling

## Testing
- Not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68f59d35a2f48331a21031635f6b5844