### PR TITLE
Add automatic make-up punch handling for missing records

### DIFF
--- a/WorkDoService/ClockInJob.cs
+++ b/WorkDoService/ClockInJob.cs
@@ -27,6 +27,7 @@ namespace WorkDoService
                 var _currentTime_Taiwan = DateTime.UtcNow.AddHours(8);
 
                 simulation.LoginSimulation();
+                await simulation.SupplementMissingPunchAsync(Enum_clocktype.ClockIn);
 
                 List<string> vacationlist = await simulation.QueryHoliday();
                 PunchHistory punchHistory = await simulation.Query_PunchHistory(Enum_clocktype.ClockIn);

--- a/WorkDoService/ClockOutJob.cs
+++ b/WorkDoService/ClockOutJob.cs
@@ -21,6 +21,7 @@ namespace WorkDoService
 
                 var simulation = new Simulation();
                 simulation.LoginSimulation();
+                await simulation.SupplementMissingPunchAsync(Enum_clocktype.ClockOut);
                 PunchHistory punchHistory = await simulation.Query_PunchHistory(Enum_clocktype.ClockOut);
 
                 if (String.IsNullOrEmpty(punchHistory.punchTime))      // 無打卡紀錄，執行打卡

--- a/WorkDoService/Models/ClockPunchQueryResponse.cs
+++ b/WorkDoService/Models/ClockPunchQueryResponse.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+
+namespace WorkDoService.Models
+{
+    public class ClockPunchQueryResponse
+    {
+        public List<ClockPunchRecord> list { get; set; }
+    }
+
+    public class ClockPunchRecord
+    {
+        public string type { get; set; }
+        public string result { get; set; }
+        public string punchDay { get; set; }
+        public string punchTime { get; set; }
+    }
+}

--- a/WorkDoService/WorkDoService.csproj
+++ b/WorkDoService/WorkDoService.csproj
@@ -91,6 +91,7 @@
     <Compile Include="Models\HolidayData.cs" />
     <Compile Include="Models\LoginData.cs" />
     <Compile Include="Models\LoginResponse.cs" />
+    <Compile Include="Models\ClockPunchQueryResponse.cs" />
     <Compile Include="Models\PunchData.cs" />
     <Compile Include="Models\PunchHistory.cs" />
     <Compile Include="Models\PunchResponse.cs" />


### PR DESCRIPTION
## Summary
- add data models and request logic to read missing clock punch records from the CCN002W API
- trigger automatic make-up punches for the current day when missing ClockIn or ClockOut entries are detected
- include the new model file in the WorkDoService project

## Testing
- dotnet build WorkDoAuto.sln *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6901b6fdcbdc833190dccf3a21cc0065