### PR TITLE
Add missing punch submission support

### DIFF
--- a/WorkDoService/ClockInJob.cs
+++ b/WorkDoService/ClockInJob.cs
@@ -27,7 +27,7 @@ namespace WorkDoService
                 var _currentTime_Taiwan = DateTime.UtcNow.AddHours(8);
 
                 simulation.LoginSimulation();
-                await simulation.SupplementMissingPunchAsync(Enum_clocktype.ClockIn);
+                await simulation.SupplementMissingPunchAsync();
 
                 List<string> vacationlist = await simulation.QueryHoliday();
                 PunchHistory punchHistory = await simulation.Query_PunchHistory(Enum_clocktype.ClockIn);

--- a/WorkDoService/ClockOutJob.cs
+++ b/WorkDoService/ClockOutJob.cs
@@ -21,7 +21,7 @@ namespace WorkDoService
 
                 var simulation = new Simulation();
                 simulation.LoginSimulation();
-                await simulation.SupplementMissingPunchAsync(Enum_clocktype.ClockOut);
+                await simulation.SupplementMissingPunchAsync();
                 PunchHistory punchHistory = await simulation.Query_PunchHistory(Enum_clocktype.ClockOut);
 
                 if (String.IsNullOrEmpty(punchHistory.punchTime))      // 無打卡紀錄，執行打卡

--- a/WorkDoService/Models/ClockPunchQueryResponse.cs
+++ b/WorkDoService/Models/ClockPunchQueryResponse.cs
@@ -9,9 +9,46 @@ namespace WorkDoService.Models
 
     public class ClockPunchRecord
     {
+        public Dictionary<string, object> fileInfoMap { get; set; }
+        public List<object> fileInfoList { get; set; }
+        public ClockPunchButtonDisplayMap btnDisplayMap { get; set; }
+        public Dictionary<string, object> customAttrMap { get; set; }
+        public long reqOid { get; set; }
+        public long depOid { get; set; }
+        public long empOid { get; set; }
         public string type { get; set; }
-        public string result { get; set; }
         public string punchDay { get; set; }
         public string punchTime { get; set; }
+        public string place { get; set; }
+        public string flowState { get; set; }
+        public string result { get; set; }
+        public string personalSummaryKey { get; set; }
+        public string groupSummaryKey { get; set; }
+        public string punchPoint { get; set; }
+        public string reqOidEnc { get; set; }
+        public string appId { get; set; }
+        public string dbkeyString { get; set; }
+        public string displayName { get; set; }
+        public string reqPunchTime { get; set; }
+        public string reqPlace { get; set; }
+        public string reqWifiPoint { get; set; }
+        public string reqWifiMac { get; set; }
+        public string reqGpsPlace { get; set; }
+        public ClockPunchLocation reqGpsLocation { get; set; }
+        public string reqFaceDeviceName { get; set; }
+        public string reqFaceDeviceOid { get; set; }
+    }
+
+    public class ClockPunchButtonDisplayMap
+    {
+        public bool view { get; set; }
+    }
+
+    public class ClockPunchLocation
+    {
+        public string text { get; set; }
+        public string value { get; set; }
+        public float? x { get; set; }
+        public float? y { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- extend `ClockPunchRecord` to surface all fields required for missing punch submissions
- add a helper that submits missing punch records directly from the query results
- update the clock-in and clock-out jobs to use the new supplement workflow

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_6901d7890d648331b0c5ddbe870e264c